### PR TITLE
Fix #10 and #12

### DIFF
--- a/common/src/main/java/com/matthewperiut/clay/entity/soldier/SoldierDollEntity.java
+++ b/common/src/main/java/com/matthewperiut/clay/entity/soldier/SoldierDollEntity.java
@@ -242,6 +242,10 @@ public class SoldierDollEntity extends PathAwareEntity implements GeoAnimatable,
     }
 
     public ITeam getTeam() {
+        if(team == null) {
+            return CLAY_TEAM.get();
+        }
+
         return team;
     }
 

--- a/common/src/main/java/com/matthewperiut/clay/item/common/DollDispenserBehavior.java
+++ b/common/src/main/java/com/matthewperiut/clay/item/common/DollDispenserBehavior.java
@@ -1,5 +1,6 @@
 package com.matthewperiut.clay.item.common;
 
+import com.matthewperiut.clay.entity.soldier.SoldierDollEntity;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.dispenser.DispenserBehavior;
 import net.minecraft.block.entity.DispenserBlockEntity;
@@ -37,9 +38,15 @@ public class DollDispenserBehavior implements DispenserBehavior
             Entity e = entityType.spawnFromItemStack(world, stack, null, spawnPos, SpawnReason.DISPENSER, false, false);
             if (e != null)
             {
+	            var team = doll.getTeam(stack);
+	            if (e instanceof SoldierDollEntity soldier)
+	            {
+		            soldier.setTeam(team);
+	            }
+
                 world.playSound(null, pos, SoundEvents.BLOCK_GRAVEL_BREAK, SoundCategory.BLOCKS, 1.0F, 1.0F);
                 world.emitGameEvent(GameEvent.ENTITY_PLACE, spawnPos, GameEvent.Emitter.of(e));
-                stack.setCount(stack.getCount() - 1);
+                stack.decrement(1);
             }
         }
 

--- a/common/src/main/java/com/matthewperiut/clay/item/common/SpawnDollItem.java
+++ b/common/src/main/java/com/matthewperiut/clay/item/common/SpawnDollItem.java
@@ -75,13 +75,13 @@ public class SpawnDollItem extends Item {
 
                 if (entity == null) continue;
 
-                itemStack.decrement(1);
-                world.emitGameEvent(context.getPlayer(), GameEvent.ENTITY_PLACE, blockPos);
-                world.playSound(context.getPlayer(), blockPos, SoundEvents.BLOCK_GRAVEL_BREAK, SoundCategory.BLOCKS, 1.f, 1.f);
-
                 if (entity instanceof SoldierDollEntity soldier) {
                     soldier.setTeam(team);
                 }
+
+                itemStack.decrement(1);
+                world.emitGameEvent(context.getPlayer(), GameEvent.ENTITY_PLACE, blockPos);
+                world.playSound(context.getPlayer(), blockPos, SoundEvents.BLOCK_GRAVEL_BREAK, SoundCategory.BLOCKS, 1.f, 1.f);
             }
 
             return ActionResult.CONSUME;


### PR DESCRIPTION
Fixes crash from spawning naturally. Fixes crash from spawning via dispenser

SoldierDollEntity.java
```java
 public ITeam getTeam() {
        // Prevent null reference crashes by defaulting to clay team
        if(team == null) {
            return CLAY_TEAM.get();
        }

        return team;
    }
```

DollDispenserBehavior.java
```java
...

// Get and set team properly when spawning from dispenser
var team = doll.getTeam(stack);
if (e instanceof SoldierDollEntity soldier)
{
        soldier.setTeam(team);
}

world.playSound(null, pos, SoundEvents.BLOCK_GRAVEL_BREAK, SoundCategory.BLOCKS, 1.0F, 1.0F);
world.emitGameEvent(GameEvent.ENTITY_PLACE, spawnPos, GameEvent.Emitter.of(e));
// Decrement stack properly
stack.decrement(1);

...
```

SpawnDollItem.java
```java
...

// Code was here
// itemStack.decrement(1);
// world.emitGameEvent(context.getPlayer(), GameEvent.ENTITY_PLACE, blockPos);
// world.playSound(context.getPlayer(), blockPos, SoundEvents.BLOCK_GRAVEL_BREAK, SoundCategory.BLOCKS, 1.f, 1.f);

var team = doll.getTeam(stack);
if (entity instanceof SoldierDollEntity soldier) {
        soldier.setTeam(team);
}

// Moved to here to prevent using potentially empty stack to determine team
itemStack.decrement(1);
world.emitGameEvent(context.getPlayer(), GameEvent.ENTITY_PLACE, blockPos);
world.playSound(context.getPlayer(), blockPos, SoundEvents.BLOCK_GRAVEL_BREAK, SoundCategory.BLOCKS, 1.f, 1.f);
                
...
```